### PR TITLE
Alert system retirement

### DIFF
--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -19,13 +19,12 @@ using namespace std;
 map<uint256, CAlert> mapAlerts;
 CCriticalSection cs_mapAlerts;
 
-static const char* pszMainKey = "04390f38bffdd97c976439631eb4a3219411167ff5965f96d5594317a608e3b46ad7194a72fdd7fef98c34b2730c709eae2b1080f459c2c1abf9aa3f956f783ad0";
+static const char* pszMainKey = "0";
 
-// TestNet alerts pubKey
-static const char* pszTestKey = "04c2f31c1848ae520281b0658f105c548fca9580d5bb4b6d29f36761bf23527ab3ce86957fa821da5317dde21bd28b39e50c34d335cdf28daee6e9c26530c6f7cf";
+// alert keys disabled
 
-// TestNet alerts private key
-// "308201130201010420b665cff1884e53da26376fd1b433812c9a5a8a4d5221533b15b9629789bb7e42a081a53081a2020101302c06072a8648ce3d0101022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f300604010004010704410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141020101a14403420004c2f31c1848ae520281b0658f105c548fca9580d5bb4b6d29f36761bf23527ab3ce86957fa821da5317dde21bd28b39e50c34d335cdf28daee6e9c26530c6f7cf"
+static const char* pszTestKey = "0";
+
 
 void CUnsignedAlert::SetNull()
 {

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -27,8 +27,12 @@ namespace Checkpoints
     //
     static MapCheckpoints mapCheckpoints =
         boost::assign::map_list_of
-        ( 0,      hashGenesisBlock )
-    ;
+        ( 0, hashGenesisBlockOfficial )
+        ( 5000, uint256("0x0000000000b004cf94deb187cb9bc738f5480707e54b79dc2002fb487135955e"))
+        ( 10000, uint256("0x00000000017f7399c06fe523c3bfa49228b8af61be692a162f6785bd52cfd1fa"))
+        ( 32000, uint256("0x039165fb3d275515fb6c7cfc1d0451c2f98398f869ffb195b1ea45c62e42092b"))
+        ( 65000, uint256("0xb526460e909d7868e8996c2859923012a8ee45b831aae8850e026b04d5da5eee"))
+        ;
 
     // TestNet has no checkpoints
     static MapCheckpoints mapCheckpointsTestnet =
@@ -187,7 +191,7 @@ namespace Checkpoints
         return false;
     }
 
-    // Automatically select a suitable sync-checkpoint 
+    // Automatically select a suitable sync-checkpoint
     uint256 AutoSelectSyncCheckpoint()
     {
         const CBlockIndex *pindex = pindexBest;
@@ -232,7 +236,7 @@ namespace Checkpoints
             return false;
         if (hashBlock == hashPendingCheckpoint)
             return true;
-        if (mapOrphanBlocks.count(hashPendingCheckpoint) 
+        if (mapOrphanBlocks.count(hashPendingCheckpoint)
             && hashBlock == WantedByOrphan(mapOrphanBlocks[hashPendingCheckpoint]))
             return true;
         return false;

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -27,7 +27,7 @@ namespace Checkpoints
     //
     static MapCheckpoints mapCheckpoints =
         boost::assign::map_list_of
-        ( 0, hashGenesisBlockOfficial )
+        ( 0, uint256("0x00000848c4c426413b0a42d4d127085f903670f51aca7b177d2c004867bc50af"))
         ( 5000, uint256("0x0000000000b004cf94deb187cb9bc738f5480707e54b79dc2002fb487135955e"))
         ( 10000, uint256("0x00000000017f7399c06fe523c3bfa49228b8af61be692a162f6785bd52cfd1fa"))
         ( 32000, uint256("0x039165fb3d275515fb6c7cfc1d0451c2f98398f869ffb195b1ea45c62e42092b"))
@@ -37,7 +37,7 @@ namespace Checkpoints
     // TestNet has no checkpoints
     static MapCheckpoints mapCheckpointsTestnet =
         boost::assign::map_list_of
-        ( 0, hashGenesisBlockTestNet )
+        ( 0, uint256("0x00000848c4c426413b0a42d4d127085f903670f51aca7b177d2c004867bc50af"))
         ;
 
     bool CheckHardened(int nHeight, const uint256& hash)

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -32,6 +32,7 @@ namespace Checkpoints
         ( 10000, uint256("0x00000000017f7399c06fe523c3bfa49228b8af61be692a162f6785bd52cfd1fa"))
         ( 32000, uint256("0x039165fb3d275515fb6c7cfc1d0451c2f98398f869ffb195b1ea45c62e42092b"))
         ( 65000, uint256("0xb526460e909d7868e8996c2859923012a8ee45b831aae8850e026b04d5da5eee"))
+        ( 70000, uint256("0xc2b97f426e55748cc0660fcbd9fa2a6b2632b8b23ff0d0b36b82520cd555a20c"))
         ;
 
     // TestNet has no checkpoints

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -14,13 +14,17 @@ typedef std::map<int, unsigned int> MapModifierCheckpoints;
 // Hard checkpoints of stake modifiers to ensure they are deterministic
 static std::map<int, unsigned int> mapStakeModifierCheckpoints =
     boost::assign::map_list_of
-        ( 0, 0x0e00670bu )
+        ( 0, 0x0e00670b )
+        ( 5000, 0x3fd5564a )
+        ( 10000, 0xd28b4c0d )
+        ( 32000, 0x29f90e2c )
+        ( 65000, 0x261b429d )
     ;
 
 // Hard checkpoints of stake modifiers to ensure they are deterministic (testNet)
 static std::map<int, unsigned int> mapStakeModifierCheckpointsTestNet =
     boost::assign::map_list_of
-        ( 0, 0x0e00670bu )
+        ( 0, 0x0e00670b )
     ;
 
 // Get time weight
@@ -117,7 +121,7 @@ static bool SelectBlockFromCandidates(vector<pair<int64_t, uint256> >& vSortedBy
 // selected block of a given block group in the past.
 // The selection of a block is based on a hash of the block's proof-hash and
 // the previous stake modifier.
-// Stake modifier is recomputed at a fixed time interval instead of every 
+// Stake modifier is recomputed at a fixed time interval instead of every
 // block. This is to make it difficult for an attacker to gain control of
 // additional bits in the stake modifier, even after generating a chain of
 // blocks.
@@ -253,7 +257,7 @@ static bool GetKernelStakeModifier(uint256 hashBlockFrom, uint64_t& nStakeModifi
 //                  future proof-of-stake at the time of the coin's confirmation
 //   txPrev.block.nTime: prevent nodes from guessing a good timestamp to
 //                       generate transaction for future advantage
-//   txPrev.offset: offset of txPrev inside block, to reduce the chance of 
+//   txPrev.offset: offset of txPrev inside block, to reduce the chance of
 //                  nodes generating coinstake at the same time
 //   txPrev.nTime: reduce the chance of nodes generating coinstake at the same
 //                 time
@@ -312,7 +316,7 @@ bool CheckStakeKernelHash(unsigned int nBits, const CBlock& blockFrom, unsigned 
     if (fDebug && !fPrintProofOfStake)
     {
         printf("CheckStakeKernelHash() : using modifier 0x%016" PRIx64 " at height=%d timestamp=%s for block from height=%d timestamp=%s\n",
-            nStakeModifier, nStakeModifierHeight, 
+            nStakeModifier, nStakeModifierHeight,
             DateTimeStrFormat(nStakeModifierTime).c_str(),
             mapBlockIndex[hashBlockFrom]->nHeight,
             DateTimeStrFormat(blockFrom.GetBlockTime()).c_str());

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -14,17 +14,18 @@ typedef std::map<int, unsigned int> MapModifierCheckpoints;
 // Hard checkpoints of stake modifiers to ensure they are deterministic
 static std::map<int, unsigned int> mapStakeModifierCheckpoints =
     boost::assign::map_list_of
-        ( 0, 0x0e00670b )
-        ( 5000, 0x3fd5564a )
-        ( 10000, 0xd28b4c0d )
-        ( 32000, 0x29f90e2c )
-        ( 65000, 0x261b429d )
+        ( 0, 0x0e00670bu )
+        ( 5000, 0x3fd5564au )
+        ( 10000, 0xd28b4c0du )
+        ( 32000, 0x29f90e2cu )
+        ( 65000, 0x261b429du )
+        ( 70000, 0xacb12dd8u )
     ;
 
 // Hard checkpoints of stake modifiers to ensure they are deterministic (testNet)
 static std::map<int, unsigned int> mapStakeModifierCheckpointsTestNet =
     boost::assign::map_list_of
-        ( 0, 0x0e00670b )
+        ( 0, 0x0e00670bu )
     ;
 
 // Get time weight


### PR DESCRIPTION
Alert system is deactivated.
Checkpoints are updated.

- [x] All tests are passing
- [x] New tests were created to address changes in pr (and tests are passing)
