### PR TITLE
docs: Update CI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center"><img src="https://github.com/AXErunners/media/raw/master/axe-logo256.png"/></p>
 
-`M`: [![Build Status](https://travis-ci.com/AXErunners/axe.svg?branch=master)](https://travis-ci.com/AXErunners/axe)
+`M`: [![Build Status](https://gitlab.com/axerunners/axe/badges/master/pipeline.svg)](https://gitlab.com/axerunners/axe/pipelines)
 
-`D`: [![Build Status](https://travis-ci.com/AXErunners/axe.svg?branch=development)](https://travis-ci.com/AXErunners/axe)
+`D`: [![Build Status](https://gitlab.com/axerunners/axe/badges/development/pipeline.svg)](https://gitlab.com/axerunners/axe/pipelines)
 
 What is Axe?
 -------------


### PR DESCRIPTION
We recently moved internal repo builds on `gitlab` so this makes sense. PRs, tho, are still relying on `travis` until theres a proper and secure way to implement builds from forks.