### PR TITLE
wallet: Fix and improve CWallet::CreateTransaction (#3668)

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1932,6 +1932,45 @@ int64_t CWalletTx::GetTxTime() const
     return n ? n : nTimeReceived;
 }
 
+int CWalletTx::GetRequestCount() const
+{
+    // Returns -1 if it wasn't being tracked
+    int nRequests = -1;
+    {
+        LOCK(pwallet->cs_wallet);
+        if (IsCoinBase())
+        {
+            // Generated block
+            if (!hashUnset())
+            {
+                std::map<uint256, int>::const_iterator mi = pwallet->mapRequestCount.find(hashBlock);
+                if (mi != pwallet->mapRequestCount.end())
+                    nRequests = (*mi).second;
+            }
+        }
+        else
+        {
+            // Did anyone request this transaction?
+            std::map<uint256, int>::const_iterator mi = pwallet->mapRequestCount.find(GetHash());
+            if (mi != pwallet->mapRequestCount.end())
+            {
+                nRequests = (*mi).second;
+
+                // How about the block it's in?
+                if (nRequests == 0 && !hashUnset())
+                {
+                    std::map<uint256, int>::const_iterator _mi = pwallet->mapRequestCount.find(hashBlock);
+                    if (_mi != pwallet->mapRequestCount.end())
+                        nRequests = (*_mi).second;
+                    else
+                        nRequests = 1; // If it's in someone else's block it must have got out
+                }
+            }
+        }
+    }
+    return nRequests;
+}
+
 void CWalletTx::GetAmounts(std::list<COutputEntry>& listReceived,
                            std::list<COutputEntry>& listSent, CAmount& nFee, std::string& strSentAccount, const isminefilter& filter) const
 {
@@ -2067,7 +2106,6 @@ CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, CBlock
         double progress_current = progress_begin;
         while (pindex && !fAbortRescan && !ShutdownRequested())
         {
-            m_scanning_progress = (progress_current - progress_begin) / (progress_end - progress_begin);
             if (pindex->nHeight % 100 == 0 && progress_end - progress_begin > 0.0) {
                 ShowProgress(_("Rescanning..."), std::max(1, std::min(99, (int)((progress_current - progress_begin) / (progress_end - progress_begin) * 100))));
             }
@@ -2329,7 +2367,7 @@ CAmount CWalletTx::GetAvailableWatchOnlyCredit(const bool fUseCache) const
     return nCredit;
 }
 
-CAmount CWalletTx::GetAnonymizedCredit(const CCoinControl* coinControl) const
+CAmount CWalletTx::GetAnonymizedCredit(bool fUseCache) const
 {
     if (!pwallet)
         return 0;
@@ -2338,7 +2376,7 @@ CAmount CWalletTx::GetAnonymizedCredit(const CCoinControl* coinControl) const
     if (IsCoinBase() || GetDepthInMainChain() < 0)
         return 0;
 
-    if (coinControl == nullptr && fAnonymizedCreditCached)
+    if (fUseCache && fAnonymizedCreditCached)
         return nAnonymizedCreditCached;
 
     CAmount nCredit = 0;
@@ -2347,10 +2385,6 @@ CAmount CWalletTx::GetAnonymizedCredit(const CCoinControl* coinControl) const
     {
         const CTxOut &txout = tx->vout[i];
         const COutPoint outpoint = COutPoint(hashTx, i);
-
-        if (coinControl != nullptr && coinControl->HasSelected() && !coinControl->IsSelected(outpoint)) {
-            continue;
-        }
 
         if (pwallet->IsSpent(hashTx, i) || !CPrivateSend::IsDenominatedAmount(txout.nValue)) continue;
 
@@ -2361,11 +2395,8 @@ CAmount CWalletTx::GetAnonymizedCredit(const CCoinControl* coinControl) const
         }
     }
 
-    if (coinControl == nullptr) {
-        nAnonymizedCreditCached = nCredit;
-        fAnonymizedCreditCached = true;
-    }
-
+    nAnonymizedCreditCached = nCredit;
+    fAnonymizedCreditCached = true;
     return nCredit;
 }
 
@@ -2586,7 +2617,7 @@ CAmount CWallet::GetAnonymizableBalance(bool fSkipDenominated, bool fSkipUnconfi
     return nTotal;
 }
 
-CAmount CWallet::GetAnonymizedBalance(const CCoinControl* coinControl) const
+CAmount CWallet::GetAnonymizedBalance() const
 {
     if (!CPrivateSendClientOptions::IsEnabled()) return 0;
 
@@ -2595,7 +2626,7 @@ CAmount CWallet::GetAnonymizedBalance(const CCoinControl* coinControl) const
     LOCK2(cs_main, cs_wallet);
 
     for (auto pcoin : GetSpendableTXs()) {
-        nTotal += pcoin->GetAnonymizedCredit(coinControl);
+        nTotal += pcoin->GetAnonymizedCredit();
     }
 
     return nTotal;
@@ -2823,12 +2854,10 @@ void CWallet::AvailableCoins(std::vector<COutput> &vCoins, bool fOnlySafe, const
             bool found = false;
             if (nCoinType == CoinType::ONLY_FULLY_MIXED) {
                 if (!CPrivateSend::IsDenominatedAmount(pcoin->tx->vout[i].nValue)) continue;
-                int nRounds = GetCappedOutpointPrivateSendRounds(COutPoint(wtxid, i));
-                found = nRounds >= CPrivateSendClientOptions::GetRounds();
+                found = IsFullyMixed(COutPoint(wtxid, i));
             } else if(nCoinType == CoinType::ONLY_READY_TO_MIX) {
                 if (!CPrivateSend::IsDenominatedAmount(pcoin->tx->vout[i].nValue)) continue;
-                int nRounds = GetCappedOutpointPrivateSendRounds(COutPoint(wtxid, i));
-                found = nRounds < CPrivateSendClientOptions::GetRounds();
+                found = !IsFullyMixed(COutPoint(wtxid, i));
             } else if(nCoinType == CoinType::ONLY_NONDENOMINATED) {
                 if (CPrivateSend::IsCollateralAmount(pcoin->tx->vout[i].nValue)) continue; // do not use collateral amounts
                 found = !CPrivateSend::IsDenominatedAmount(pcoin->tx->vout[i].nValue);
@@ -4134,6 +4163,9 @@ bool CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey, CCon
                 updated_hahes.insert(txin.prevout.hash);
             }
         }
+
+        // Track how many getdata requests our transaction gets
+        mapRequestCount[wtxNew.GetHash()] = 0;
 
         // Get the inserted-CWalletTx from mapWallet so that the
         // fInMempool flag is cached properly


### PR DESCRIPTION
_Partial_

* wallet: Remove unused vecTxDSInTmp in CWallet::CreateTransaction

* wallet: Calculate fees earlier and respect them in change determination

* wallet: Cleanup obsolete code in CreateTransaction

This parts were needed before when the fee was calculated after the change was assigned. But now with the previous commit the fee is calculated upfront and respected properly from the begining. So there is no longer a need of increasing or decreasing the change depending on the fee as it has the correct value directly after its added.

* wallet: Try to pick other inputs if the selected ones are too small

If nChange is negative in this cases it means that the selected inputs can't cover the amount to send and the required transaction fee. So we just add the missing amount to nFeeRet. This leads to the algo trying to pick larger inputs in the next loop (with nFeeRet more duffs than in the previous loop). This process gets repeated until the selected amount is enough to cover all the costs or until the requested amount can't be selected anymore (not enough utxos to cover it).

* wallet: Break the loop if the transaction is ready

* wallet: Respect additional amount from previous cycles

* wallet: Respect available in coin selection, try all coins in last round

* wallet: Avoid potential infinite loop, just in case..

* wallet: Fix signing in CreateTransaction

Prior it was messed because of 60d96a1a28b55f071c6144f248e136679c44337e. Set coins isn't sorted the same way as txNew.vin is so it sometimes may pick wrong coins for signing the input.

* wallet: Fix change calculation if "subtract fee from amount" is enabled

* wallet: Return after fee calc if no or not enough amount available

Return the proper fail reason. Prior to this commit it run into "Exceeded max tried".

Note: Only return if not enough amount is available if we can't subtract fee from amount.

* wallet: Fix break logic if available amount is not enough

* Revert "wallet: Fix signing in CreateTransaction"

This reverts commit 5fcdc0f00e7b961ebb62c94d17d585537e911309.

* Use a vector of coins instead of a set in CreateTransaction and sort it in a BIP69 compliant way when needed

* wallet: Adjust comment

* Cleaner usage of nChangePosRequest/InOut

* Simplify some fail/try-again conditions (fixed)

* Loop through outputs to update change output position only when outputs are sorted for BIP69

No need to do this for non-bip69 cases (i.e. when a specific change output position was requested and assigned)

* Avoid implicit conversions of int-s into bool-s

* Move `nAmountLeft == nFeeRet` check higher, tweak comments

* wallet: Fix some formatting

* wallet: Improve CTxIn creation in CreateTransaction

## Description

Please describe the purpose of the pull request.

## Checklist

- [ ] All tests are passing
- [ ] New tests were created to address changes in pr (and tests are passing)
- [ ] Updated README and/or documentation, if necessary

Thanks for contributing!
